### PR TITLE
Fix APIs authorization

### DIFF
--- a/Jellyfin.Plugin.FinTube/Api/FinTubeActivityController.cs
+++ b/Jellyfin.Plugin.FinTube/Api/FinTubeActivityController.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.FinTube.Api;
 
 [ApiController]
-[Authorize(Policy = "DefaultAuthorization")]
+[Authorize(Roles = "Administrator")]
 [Route("fintube")]
 [Produces(MediaTypeNames.Application.Json)]
 public class FinTubeActivityController : ControllerBase


### PR DESCRIPTION
Authorization were not working anymore with the latest release of Jellyfin server

Fixes this issue : https://github.com/AECX/FinTube/issues/10